### PR TITLE
editorial suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,32 @@
 
 ![](.gitbook/assets/cellxgene_logo.svg)
 
-Cellxgene is a collection of computational tools enabling the exploration, analysis, and reuse of single cell data. The cellxgene ecosystem is currently composed of the [cellxgene data portal](https://cellxgene.cziscience.com/) \(which includes the hosted cellxgene explorer\) and the [cellxgene desktop explorer](https://github.com/chanzuckerberg/cellxgene). 
+Cellxgene is a collection of software tools enabling the exploration, analysis, and reuse of single cell data. The cellxgene ecosystem is composed of the [cellxgene data portal](https://cellxgene.cziscience.com/) \(which includes the hosted cellxgene explorer\) and the [cellxgene desktop explorer](https://github.com/chanzuckerberg/cellxgene).
 
 ![cellxgene explorer](.gitbook/assets/image%20%281%29.png)
 
-The cellxgene data portal is a place where you can search and download publicly available single cell datasets. Each dataset that is hosted on the cellxgene data portal is accompanied by a hosted instance of the cellxgene explorer; enabling frictionless visualization, exploration, and basic analysis of single cell data \(with the capability to handle datasets with millions of cells\). To serve use cases where it is not possible to submit your data to our portal, cellxgene is also available as a "desktop" explorer which can be used locally or in a self-hosted setup \([documentation on self-hosting](desktop/self-hosting/)\). In most cases, using the hosted explorer is preferred and sufficient. However, there are a select few scenarios where it may be preferable to use desktop explorer \(see [use cases](./#use-cases) below\) 
+The cellxgene data portal enables publishing, search and download of publicly available single cell datasets. Each dataset that is hosted on the cellxgene data portal is accompanied by a hosted instance of the cellxgene explorer; enabling frictionless visualization, exploration, and basic analysis of single cell data \(with the capability to handle datasets with millions of cells\). Cellxgene is also available as a "desktop" explorer which can be used locally or in a self-hosted setup \([documentation on self-hosting](desktop/self-hosting/)\). In most cases, using the hosted explorer is preferred and sufficient. However, there are a select few scenarios where it may be preferable to use desktop explorer \(see [use cases](./#use-cases) below\)
 
 ![cellxgene data portal](.gitbook/assets/image%20%288%29.png)
 
 ### Use Cases
 
-As a web based data platform, the **cellxgene data portal** and **hosted explorer** system serve the following use cases around data sharing and consumption:
+As a web based data platform, the **cellxgene data portal** and **hosted explorer** system serve the following data sharing and consumption use cases:
 
 * Disseminating self-authored single cell publication data
 * Finding publicly available relevant single cell datasets and running comparisons between them
 * Quickly visualizing single cell publication data of other authors
-* Single cell data reuse \(i.e. integration or benchmarking\)
+* Downloading and reusing single cell data \(i.e. for integrative analysis or benchmarking\)
 
-The **desktop explorer** serves a different set of use cases. Namely:
+The **desktop explorer** serves a different set of use cases:
 
-*  Annotation and re-analysis of single cell datasets
-* Collaboration and iteration of analysis on a dataset
-* Setting up a closed self-hosted system for high sensitivity data
+* Annotation and re-analysis of single cell datasets
+* Collaborative analysis of a dataset
+* Setting up a closed self-hosted system for private data
 
 ### **Explorer Features**
 
-To get a sense of the capabilities of the cellxgene explorers, here is a rundown of their features, along with the notable differences between the hosted and desktop versions. To learn more about the cellxgene explorers, take a look at our [explorer documentation](explorer/feature-overview/).
+To get a sense of the capabilities of the cellxgene explorers, here is a rundown of their features, along with the notable differences between the hosted and desktop versions. To learn more about the cellxgene explorers, take a look at the [explorer documentation](explorer/feature-overview/).
 
 |  |                  Hosted |                  Desktop |
 | :--- | :--- | :--- |
@@ -45,10 +45,10 @@ To get a sense of the capabilities of the cellxgene explorers, here is a rundown
 
 If you are ready and raring to see what cellxgene is capable of, you can:
 
-* jump right into a [hosted cellxgene explorer instance](https://cellxgene.cziscience.com/e/human_cell_landscape.cxg/) and start exploring
-* find out more about the cellxgene data portal and data contribution in the [corresponding section](portal/hosted-intro.md) of this documentation
-* read about how to use the cellxgene explorer via the [explorer documentation](explorer/feature-overview/)
-* or if your use case demands it, you can check out information that is relevant to using [cellxgene desktop](desktop/desktop-intro.md).
+* Jump right into a [hosted cellxgene explorer instance](https://cellxgene.cziscience.com/e/human_cell_landscape.cxg/) and start exploring
+* Find out more about the cellxgene data portal and data contribution in the [corresponding section](portal/hosted-intro.md) of this documentation
+* Read about how to use the cellxgene explorer via the [explorer documentation](explorer/feature-overview/)
+* Or if your use case demands it, you can check out information that is relevant to using [cellxgene desktop](desktop/desktop-intro.md)
 
 Additionally, here are some important links for resources that exist outside of this documentation site:
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,21 +4,21 @@
 
 ## Portal
 
-* [Intro to Portal](portal/hosted-intro.md)
+* [Introduction](portal/hosted-intro.md)
 * [Data Portal](portal/data-portal.md)
 * [Publishing and Data Submission](portal/publishing.md)
 
 ## Explorer
 
-* [Feature Intro and UI](explorer/feature-overview/README.md)
-  * [Universal Features](explorer/feature-overview/universal-features.md)
-  * [Desktop Features](explorer/feature-overview/desktop-features/README.md)
-    * [Annotations](explorer/feature-overview/desktop-features/annotations.md)
+* [Introduction](explorer/feature-overview/README.md)
+* [Universal Features](explorer/feature-overview/universal-features.md)
+* [Desktop Features](explorer/feature-overview/desktop-features/README.md)
+  * [Annotations](explorer/feature-overview/desktop-features/annotations.md)
 * [Algorithms](explorer/algorithms.md)
 
 ## Desktop
 
-* [Intro to Desktop Explorer](desktop/desktop-intro.md)
+* [Introduction](desktop/desktop-intro.md)
 * [Quick Start](desktop/quick-start/README.md)
   * [Demo data](desktop/quick-start/demo-data.md)
 * [Install](desktop/install.md)

--- a/desktop/desktop-intro.md
+++ b/desktop/desktop-intro.md
@@ -1,9 +1,5 @@
 # Intro to Desktop Explorer
 
-{% hint style="info" %}
-Cellxgene desktop explorer will be maintained, but no longer actively developed by the cellxgene team
-{% endhint %}
-
 Cellxgene desktop explorer is a tool in the cellxgene suite that should be used for basic analysis and exploration of your data. The use cases that are covered in this category are:
 
 * When you need to work with other team members to make **collaborative annotations** of your dataset

--- a/portal/hosted-intro.md
+++ b/portal/hosted-intro.md
@@ -1,6 +1,6 @@
 # Intro to Portal
 
-### About and use cases
+### Features & Functionality
 
 The [cellxgene data portal](https://cellxgene.cziscience.com/) is a single cell publishing platform that is optimized for the access, exploration, and reuse of single cell data. In addition to providing a [standardized data corpus](https://github.com/chanzuckerberg/single-cell-curation/blob/main/docs/corpora_schema.md), the cellxgene data portal serves the following use cases:
 


### PR DESCRIPTION
Some minor editorial suggestions. I was only able to run a partial review. 

* There was a bit of inconsistency in how enumerated lists of bullets are displayed. One style should be selected and used throughout. The style that I saw that was most common was capital letters and no periods. I standardized on that in the documents I read through. 
* Generally, I prefer not to use pronouns in documentation (we/our/us/I)
* I removed a note about no longer developing the explorer - we're not prioritizing feature development this year. The way I want to convey that is by adding a roadmap section where desktop doesn't feature. That's coming soon. 
* I standardized the names of the section headers. Generally I prefer using full words instead of abbreviations (Introduction > Intro). 